### PR TITLE
add device info in prototype Framework7 class

### DIFF
--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -949,6 +949,17 @@ declare class Swiper {
 declare class Framework7 {
 	constructor(options?: Framework7.Framework7Options);
 	
+	//device info
+	android: boolean;
+	androidChrome: boolean;
+	ios: boolean;
+	ipad: boolean;
+	iphone: boolean;
+	pixelRatio: number;
+	statusBar: boolean;
+	os: string;
+	osVersion: string;
+		
 	// Views
 	views: Framework7.View[]
 	addView(selector: string | HTMLElement | Dom7.Dom7, parameters: Framework7.ViewParameters) : Framework7.View;


### PR DESCRIPTION
To turn ease implements this tutorial in typescript: 
http://framework7.io/tutorials/maintain-both-ios-and-material-themes-in-single-app.html
