### PR TITLE
New page callback, fixing eq() return type and Dom7 event

### DIFF
--- a/dom7.d.ts
+++ b/dom7.d.ts
@@ -108,7 +108,7 @@ declare namespace Dom7 {
 		text(newTextContent : string) : Dom7;
 		is(CSSSelector : string | Element | Dom7) : boolean;
 		index() : boolean;
-		eq(index : number) : boolean;
+		eq(index : number) : Dom7;
 		append(element : string | Element | Dom7) : Dom7;
 		append(element : string | Element | Dom7) : Dom7;
 		appendTo(element : string | Element | Dom7) : Dom7;

--- a/dom7.d.ts
+++ b/dom7.d.ts
@@ -179,7 +179,8 @@ declare namespace Dom7 {
 		(element: Element): Dom7;
 		(element: Document): Dom7;
 		(elementArray: Element[]): Dom7;
-		
+		(event: EventTarget): Dom7;
+
 		// Utility
 		each(callback : (index : number, element : any) => void) : void;
 		parseUrlQuery(url : string) : any;

--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -1077,6 +1077,7 @@ declare class Framework7 {
 	// not documented
 	onPageBeforeInit(pageName: string, callback: (page: Framework7.PageData) => void): Framework7.PageCallbackObject;
 	onPageInit(pageName: string, callback: (page: Framework7.PageData) => void): Framework7.PageCallbackObject;
+	onPageReinit(pageName: string, callback: (page: Framework7.PageData) => void): Framework7.PageCallbackObject;
 	onPageBeforeAnimation(pageName: string, callback: (page: Framework7.PageData) => void): Framework7.PageCallbackObject;
 	onPageAfterAnimation(pageName: string, callback: (page: Framework7.PageData) => void): Framework7.PageCallbackObject;
 	onPageBeforeRemove(pageName: string, callback: (page: Framework7.PageData) => void): Framework7.PageCallbackObject;

--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -508,14 +508,15 @@ declare namespace Framework7 {
 	}
 
 	interface PickerColumn {
-		container: Dom7.Dom7;
-		items: Dom7.Dom7;
-		value: any;
-		displayValue: any;
-		activeIndex: number;
+		container?: Dom7.Dom7;
+		items?: Dom7.Dom7;
+		values: Array<any>;
+		displayValues?: Array<any>;
+		activeIndex?: number;
+		textAlign?: string;
 
-		setValue(value: any, duration: number): void;
-		replaceValues(values: any[], displayValues: any[]): void;
+		setValue?(value: any, duration: number): void;
+		replaceValues?(values: any[], displayValues: any[]): void;
 	}
 
 	interface PickerOptions {

--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -352,7 +352,7 @@ declare namespace Framework7 {
 		navbarInnerContainer?: HTMLElement;
 		swipeBack?: boolean;
 		context?: any;
-		fromPage?: any;
+		fromPage?: PageData;
 	}
 
 	interface View {


### PR DESCRIPTION
Some small fixes:
- The Dom7 constructor can also take an EventTarget as input
- eq() returns an actual DOM element, not a boolean
- There is an onePageReinit page callback as well.
