### PR TITLE
selector added to Interface View

### DIFF
--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -364,6 +364,7 @@ declare namespace Framework7 {
 		activePage: PageData;
 		main: boolean;
 		router: Router;
+		selector: string;
 
 		hideNavbar(): void;
 		showNavbar(): void;


### PR DESCRIPTION
Adds **selector** to the View interface. When trying to find a view through **this.app.views** **url** is insufficient because **url** points to the page that is currently loaded in the view. Selector is a css class but at least allows us to specifically match for the view. An example follows with usage.

```
var view = this.app.views.find((value: Framework7.View) => {
    return value.selector === viewSelector;
});
```