### PR TITLE
SearchBar callbacks and Messages Parameters

### DIFF
--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -655,10 +655,12 @@ declare namespace Framework7 {
 	}
 
 	interface MessagesOptions {
-		autoLayout: boolean;
-		newMessagesFirst: boolean;
-		messages: Message[];
-		messageTemplate: string;
+		autoLayout?: boolean;
+		newMessagesFirst?: boolean;
+		scrollMessages?: boolean;
+		scrollMessagesOnlyOnEdge?: boolean;
+		messages?: Message[];
+		messageTemplate?: string;
 	}
 
 	interface Messages {

--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -1102,10 +1102,10 @@ declare class Framework7 {
 	calendar(parameters: Framework7.CalendarOptions): Framework7.Calendar;
 	
 	// Pull to Refresh
-	pullToRefreshDone(ptrContent: string | HTMLElement | Dom7.Dom7) : void;
-	pullToRefreshTrigger(ptrContent: string | HTMLElement | Dom7.Dom7) : void;
-	destroyPullToRefresh(ptrContent: string | HTMLElement | Dom7.Dom7) : void;
-	initPullToRefresh(ptrContent: string | HTMLElement | Dom7.Dom7) : void;
+	initPullToRefresh(pageContainer: string | HTMLElement | Dom7.Dom7) : void;
+	pullToRefreshDone(ptrContent?: string | HTMLElement | Dom7.Dom7) : void;
+	pullToRefreshTrigger(ptrContent?: string | HTMLElement | Dom7.Dom7) : void;
+	destroyPullToRefresh(ptrContent?: string | HTMLElement | Dom7.Dom7) : void;
 	
 	// Infinite Scroll
 	attachInfiniteScroll(container: string | HTMLElement | Dom7.Dom7) : void;

--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="dom7.d.ts" />
+/// <reference path="template7.d.ts" />
 
 declare namespace Framework7 {
 	interface PageCallbackObject {

--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -669,9 +669,9 @@ declare namespace Framework7 {
 		container: Dom7.Dom7;
 
 		addMessage(messageParameters: MessageOptions, method?: string, animate?: boolean): HTMLElement;
-		appendMessage(messageParameters: MessageOptions, animate: boolean): HTMLElement;
-		prependMessage(messageParameters: MessageOptions, animate: boolean): HTMLElement;
-		addMessages(messages: Message[], method: string, animate: boolean): HTMLElement[];
+		appendMessage(messageParameters: MessageOptions, animate?: boolean): HTMLElement;
+		prependMessage(messageParameters: MessageOptions, animate?: boolean): HTMLElement;
+		addMessages(messages: Message[], method?: string, animate?: boolean): HTMLElement[];
 		removeMessage(message: Message): boolean;
 		removeMessages(messages: Message[]): boolean;
 		scrollMessages(): void;

--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -668,7 +668,7 @@ declare namespace Framework7 {
 		params: MessagesOptions;
 		container: Dom7.Dom7;
 
-		addMessage(messageParameters: MessageOptions, method: string, animate: boolean): HTMLElement;
+		addMessage(messageParameters: MessageOptions, method?: string, animate?: boolean): HTMLElement;
 		appendMessage(messageParameters: MessageOptions, animate: boolean): HTMLElement;
 		prependMessage(messageParameters: MessageOptions, animate: boolean): HTMLElement;
 		addMessages(messages: Message[], method: string, animate: boolean): HTMLElement[];

--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -1129,6 +1129,11 @@ declare class Framework7 {
 	onPageBack(pageName: string, callback: (page: Framework7.PageData) => void): Framework7.PageCallbackObject;
 	onPageAfterBack(pageName: string, callback: (page: Framework7.PageData) => void): Framework7.PageCallbackObject;
 
+	// Resizable textarea
+	resizeTextarea(textarea: string | HTMLElement | Dom7.Dom7): void;
+	resizableTextarea(textarea: string | HTMLElement | Dom7.Dom7): void;
+	destroyResizableTextarea(pageContainer: string | HTMLElement | Dom7.Dom7): void;
+	initPageResizableTextarea(pageContainer: string | HTMLElement | Dom7.Dom7): void;
 }
 
 declare module "framework7" {

--- a/framework7.d.ts
+++ b/framework7.d.ts
@@ -206,10 +206,10 @@ declare namespace Framework7 {
 		hideDividers?: boolean;
 		hideGroups?: boolean;
 		// Callbacks
-		onSearch?: (query: string) => void;
-		onEnable?: (query: string) => void;
-		onDisable?: (query: string) => void;
-		onClear?: (query: string) => void;
+		onSearch?: (s: SearchBar) => void;
+		onEnable?: (s: SearchBar) => void;
+		onDisable?: (s: SearchBar) => void;
+		onClear?: (s: SearchBar) => void;
 	}
 
 	interface SearchBar {


### PR DESCRIPTION
1) SearchBar's callbacks "s" parameter is SearchBar instance.
onSearch, onEnable, onDisable and onClear callbacks get SearchBar instance as parameter.

https://framework7.io/docs/searchbar.html#search-bar-parameters

console.log(s) output on onSearch callback:

<img width="1090" alt="2017-10-22 14 29 47" src="https://user-images.githubusercontent.com/390483/31861428-d5e6563a-b735-11e7-8a96-77029925f314.png">

2) All MessagesOptions are optional + add 2 MessagesOptions options
